### PR TITLE
Use Inline Array Annotation for dependency injection

### DIFF
--- a/window-leave.js
+++ b/window-leave.js
@@ -19,7 +19,7 @@
 					"opened": "=",
 					"onOpen": "&"
 				},
-				controller: function ($scope, $element, $attrs) {
+				controller: ['$scope', '$element', function ($scope, $element, $attrs) {
 					$scope.disabledByUser = false;
 					$scope.displayed = false;
 					$scope.dismissOn = !$scope.dismissOn ? "mouseenter" : $scope.dismissOn;
@@ -197,7 +197,7 @@
 							$timeout.cancel(dismissTimer);
 						}
 					}
-				},
+				}],
 				link: function ($scope, $element, $attrs, $ctrl, transclude) {
 					transclude($scope.$new(), function (clone) {
 						$element.append(clone);


### PR DESCRIPTION
Cause if you minify your app and don't use ng-annotate (unmaintained)
or babel-plugin-angularjs-annotate replacement, app will crash.

Using Inline Array Annotation, is a safer a simpler (no external module)
to avoid issue when we minify code.

See:
https://docs.angularjs.org/guide/di